### PR TITLE
housekeeping: strip down package references

### DIFF
--- a/src/Dhgms.DocFx.MermaidJs.Plugin/Dhgms.DocFx.MermaidJs.Plugin.csproj
+++ b/src/Dhgms.DocFx.MermaidJs.Plugin/Dhgms.DocFx.MermaidJs.Plugin.csproj
@@ -8,12 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Docfx.MarkdigEngine.Extensions" Version="2.78.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
-    <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-    <PackageReference Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.3.1" PrivateAssets="all" />
-    <PackageReference Include="System.Composition" Version="10.0.10" PrivateAssets="all" />
-    <PackageReference Include="System.Reactive" Version="6.1.0" />
     <PackageReference Include="Whipstaff.Markdig" Version="9.1.205" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
removing pkg references now DFM is redundant